### PR TITLE
Fixed error

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
 name: StarGate-Atlantis
 main: alemiz\sga\StarGateAtlantis
 version: 2.1.0
-api: 3.0.0
+api: 4.0.0


### PR DESCRIPTION
Couldnt load with error message " Could not load plugin 'StarGate-Atlantis': Incompatible API version (plugin requires one of: 3.0.0)"